### PR TITLE
replaced lint-stage 'next lint' to 'eslint'

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "lint-staged": {
     "src/**/*.{tsx,ts}": [
-      "next lint",
+      "eslint",
       "prettier . --write"
     ],
     "**/*.{json,md,yml,yaml}": [


### PR DESCRIPTION
## Description

replaced lint-stage command from `next lint` to `eslint` to fix the error from pre commit hook. This seems to be an issue specifically with next where lint isn't working when `pages` folder isn't in root directory (currently it is in `src/pages`). `next lint` also doesn't obey the eslint rules and lets issues pass through the pre-commit check. Using `eslint` fixes all of the aforementioned issues.

Fixes #140 

## Changes Include
- [x] Bug fix 🐛 (non-breaking change which fixes an issue)
- [x] Tooling ⚙️ (Changes to the build process or auxiliary tools and libraries such as documentation generation)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Make changes to the repo, stage those changes, and commit the changes - commits fails
- [ ] Using `eslint` changes in this PR, repeat the above process - commit is successful

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings